### PR TITLE
Refactor to use non-allocating types and static address map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,6 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "clap",
- "lazy_static",
  "serde",
  "serde_derive",
  "serde_json",
@@ -283,12 +282,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,8 @@ clap = { version = "3", features = ["derive"] }
 toml = "0"
 serde_derive = "1"
 bytemuck = { version = "*", features = ["derive"] }
-lazy_static = "1.4.0"
+
+[profile.release]
+codegen-units = 1
+strip = true
+lto = true

--- a/src/samus.rs
+++ b/src/samus.rs
@@ -1,0 +1,147 @@
+pub(super) static SAMUS_ADDR_MAP: SamusRamMap = SamusRamMap([
+    0x09C2, 0x09C4, 0x09C6, 0x09C8, 0x09CA, 0x09CC, 0x09CE, 0x09D0, 0x09A2, 0x09A4, 0x09A6, 0x09A8,
+    0x09D6, 0x09D4,
+]);
+
+#[derive(Debug, Clone)]
+pub struct Samus {
+    pub(super) hp: u16,
+    pub(super) max_hp: u16,
+    pub(super) missiles: u16,
+    pub(super) max_missiles: u16,
+    pub(super) supers: u16,
+    pub(super) max_supers: u16,
+    pub(super) pbs: u16,
+    pub(super) max_pbs: u16,
+    pub(super) equipped_items: Items,
+    pub(super) collected_items: Items,
+    pub(super) equipped_beams: Beams,
+    pub(super) collected_beams: Beams,
+    pub(super) reserve_hp: u16,
+    pub(super) max_reserve_hp: u16,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum SamusField {
+    HP,
+    MaxHP,
+    Missiles,
+    MaxMissiles,
+    Supers,
+    MaxSupers,
+    PBs,
+    MaxPBs,
+    EquippedItems,
+    CollectedItems,
+    EquippedBeams,
+    CollectedBeams,
+    ReserveHP,
+    MaxReserveHP,
+}
+
+pub(super) struct SamusRamMap([u16; 14]);
+
+impl std::ops::Index<SamusField> for SamusRamMap {
+    type Output = u16;
+
+    fn index(&self, field: SamusField) -> &Self::Output {
+        &self.0[field as usize]
+    }
+}
+
+#[allow(dead_code)]
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum Item {
+    Varia = 0x0001,
+    SpringBall = 0x0002,
+    MorphBall = 0x0004,
+    ScrewAttack = 0x0008,
+    Gravity = 0x0020,
+    HiJumpBoots = 0x0100,
+    SpaceJump = 0x0200,
+    Bombs = 0x1000,
+    SpeedBooster = 0x2000,
+    Grapple = 0x4000,
+    XRay = 0x8000,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub(super) struct Items(u16);
+
+#[allow(dead_code)]
+impl Items {
+    pub fn set(&mut self, item: Item) {
+        self.0 |= item as u16;
+    }
+}
+
+impl From<u16> for Items {
+    fn from(bits: u16) -> Self {
+        Items(bits)
+    }
+}
+
+impl From<Items> for u16 {
+    fn from(items: Items) -> Self {
+        items.0
+    }
+}
+
+#[allow(dead_code)]
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum Beam {
+    Wave = 0x0001,
+    Ice = 0x0002,
+    Spazer = 0x0004,
+    Plasma = 0x0008,
+    Charge = 0x1000,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub(super) struct Beams(u16);
+
+#[allow(dead_code)]
+impl Beams {
+    pub fn set(&mut self, beam: Beam) {
+        self.0 |= beam as u16;
+    }
+}
+
+impl From<u16> for Beams {
+    fn from(bits: u16) -> Self {
+        Beams(bits)
+    }
+}
+
+impl From<Beams> for u16 {
+    fn from(beams: Beams) -> Self {
+        beams.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_address_map() {
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::HP], 0x09C2);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::MaxHP], 0x09C4);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::Missiles], 0x09C6);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::MaxMissiles], 0x09C8);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::Supers], 0x09CA);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::MaxSupers], 0x09CC);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::PBs], 0x09CE);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::MaxPBs], 0x09D0);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::EquippedItems], 0x09A2);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::CollectedItems], 0x09A4);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::EquippedBeams], 0x09A6);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::CollectedBeams], 0x09A8);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::ReserveHP], 0x09D6);
+        assert_eq!(SAMUS_ADDR_MAP[SamusField::MaxReserveHP], 0x09D4);
+    }
+}


### PR DESCRIPTION
Hi, like your project and figured I'd offer this up. This PR replaces some usage of allocating types like BTreeMap and HashSet with u16-backed bitfields. This allows us to express some operations with a little less code and should be slightly more performant. Additionally, the address map has been converted to an array indexable by the `SamusField` enum instead of using lazy_static. There's a test to ensure correctness for that. I tried to figure out a way to move any error in the map layout to a compile time error, but unfortunately there wasn't a convenient way to do so because indexing isn't const.

I'd like to apologize in advance for any logic errors as I don't have an FxPak to test this with and I couldn't get it to quickly work with emu-nwa. It should be correct to the best of my knowledge though.